### PR TITLE
Added support for autoencoders and 2D tiled arrays

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# 127 is width of the Github code viewer,
+# black default is 88 so this will only warn about comments >127
+max-line-length = 127
+# Ignore errors due to incompatibility with black
+#https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
+extend-ignore = E203,E701

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+default_language_version:
+    python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: debug-statements
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.25.0
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [commit]
+  # Using this mirror lets us use mypyc-compiled black, which is about 2x faster
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.2.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black"]

--- a/pca_run.py
+++ b/pca_run.py
@@ -1,11 +1,13 @@
-from sklearn.decomposition import PCA
 import argparse
 import pathlib
+import time
+
 import numpy as np
 import pandas as pd
-import time
 import yaml
+from sklearn.decomposition import PCA
 from tiled.client import from_uri
+
 from utils import load_images_from_directory
 
 """ Compute PCA
@@ -13,11 +15,14 @@ from utils import load_images_from_directory
     Output: latent vectors of shape (N, 2) or (N, 3)
 """
 
+
 def computePCA(data, n_components=2, standarize=False):
-    data = data.reshape(data.shape[0], -1)
+    if len(data.shape) > 2:
+        data = data.reshape(data.shape[0], -1)
     pca = PCA(n_components=n_components)
     data_pca = pca.fit_transform(data)
     return data_pca
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -32,7 +37,9 @@ if __name__ == "__main__":
     # Validate and load I/O related parameters
     io_parameters = parameters["io_parameters"]
     # Check input and output dir are provided
-    assert io_parameters["output_dir"], "Output dir (dir to save the computed latent vactors) not provided for training."
+    assert io_parameters[
+        "output_dir"
+    ], "Output dir (dir to save the computed latent vactors) not provided for training."
 
     # Validate model parameters:
     model_parameters = parameters["model_parameters"]
@@ -40,51 +47,67 @@ if __name__ == "__main__":
     print(model_parameters)
 
     # output directory
-    output_dir = pathlib.Path(io_parameters["output_dir"] + "/" + io_parameters["uid_save"])
-    
+    output_dir = pathlib.Path(
+        io_parameters["output_dir"] + "/" + io_parameters["uid_save"]
+    )
+
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    ## Load images from given data_uris
+    # Load images from given data_uris
     stacked_images = None
-    data_uris = io_parameters["data_uris"]
 
-    print(data_uris)
-    for uri in data_uris:
-        if uri == 'data/example_shapes/Demoshapes.npz': # example dataset 
-            images = np.load(uri)['arr_0']    
-        if uri == 'data/example_shapes/Demoshapes.npz': # example dataset 
-            images = np.load(uri)['arr_0']
-        elif uri == 'data/example_latentrepresentation/f_vectors.parquet': # example dataset 
-            df = pd.read_parquet(uri)
-            images = df.values
-        # elif images_dir.split('.')[-1] == 'parquet': # data clinic
-        #     df = pd.read_parquet(images_dir)
-        #     images = df.values
-            
-        else: 
-            # FM, file system or tiled
-            if io_parameters["data_type"] == "file":
-                images = load_images_from_directory(io_parameters["root_uri"] + "/" + uri)
-            else: # tiled
-                tiled_client = from_uri(io_parameters["root_uri"], api_key=io_parameters["data_tiled_api_key"])
-                images = tiled_client[uri][:]
+    uid_retrieve = io_parameters["uid_retrieve"]
+    if uid_retrieve is not None:
+        # Get feature vectors from autoencoder
+        stacked_images = pd.read_parquet(
+            f"data/mlexchange_store/{uid_retrieve}/f_vectors.parquet"
+        ).values
 
-        if stacked_images is None:
-            stacked_images = images
-        else:
-            stacked_images = np.concatenate(( stacked_images , images ), axis=0) 
+    else:
+        data_uris = io_parameters["data_uris"]
+
+        for uri in data_uris:
+            if uri == "data/example_shapes/Demoshapes.npz":  # example dataset
+                images = np.load(uri)["arr_0"]
+            if uri == "data/example_shapes/Demoshapes.npz":  # example dataset
+                images = np.load(uri)["arr_0"]
+            elif (
+                uri == "data/example_latentrepresentation/f_vectors.parquet"
+            ):  # example dataset
+                df = pd.read_parquet(uri)
+                images = df.values
+
+            else:
+                # FM, file system or tiled
+                if io_parameters["data_type"] == "file":
+                    images = load_images_from_directory(
+                        io_parameters["root_uri"] + "/" + uri
+                    )
+                else:  # tiled
+                    tiled_client = from_uri(
+                        io_parameters["root_uri"],
+                        api_key=io_parameters["data_tiled_api_key"],
+                    )
+                    images = tiled_client[uri][:]
+
+            if stacked_images is None:
+                stacked_images = images
+            else:
+                stacked_images = np.concatenate((stacked_images, images), axis=0)
 
     start_time = time.time()
 
     # Run PCA
-    latent_vectors = computePCA(stacked_images, n_components=model_parameters['n_components'])
+    latent_vectors = computePCA(
+        stacked_images, n_components=model_parameters["n_components"]
+    )
     print("Latent vector shape: ", latent_vectors.shape)
-    
+
     # Save latent vectors
-    output_name = 'latent_vectors.npy'
-    save_path = str(output_dir) + '/' + output_name
+    output_name = "latent_vectors.npy"
+    save_path = str(output_dir) + "/" + output_name
     print(save_path)
-    np.save(str(output_dir) + '/' + output_name, latent_vectors)
+    np.save(str(output_dir) + "/" + output_name, latent_vectors)
 
     print("PCA done, latent vector saved.")
     end_time = time.time()

--- a/pca_run.py
+++ b/pca_run.py
@@ -67,12 +67,10 @@ if __name__ == "__main__":
         data_uris = io_parameters["data_uris"]
 
         for uri in data_uris:
-            if uri == "data/example_shapes/Demoshapes.npz":  # example dataset
-                images = np.load(uri)["arr_0"]
-            if uri == "data/example_shapes/Demoshapes.npz":  # example dataset
+            if "data/example_shapes/Demoshapes.npz" in uri:  # example dataset
                 images = np.load(uri)["arr_0"]
             elif (
-                uri == "data/example_latentrepresentation/f_vectors.parquet"
+                "data/example_latentrepresentation/f_vectors.parquet" in uri
             ):  # example dataset
                 df = pd.read_parquet(uri)
                 images = df.values
@@ -89,6 +87,8 @@ if __name__ == "__main__":
                         api_key=io_parameters["data_tiled_api_key"],
                     )
                     images = tiled_client[uri][:]
+                    if len(images.shape) == 2:
+                        images = images[np.newaxis, :, :]
 
             if stacked_images is None:
                 stacked_images = images


### PR DESCRIPTION
This PR adds the following:
- Allows the use of previous feature vectors as input, such as the ones coming from data clinic and mlcoach
- Supports 2D tiled containers, e.g. single image per container
- Slight modification to the example path to accommodate full data path. This is necessary when running outside containers (docker/podman)